### PR TITLE
修复回调接口直接 GET 时, undefined index 的问题

### DIFF
--- a/src/Payjs.php
+++ b/src/Payjs.php
@@ -135,7 +135,7 @@ class Payjs
     // 校验数据签名
     public function checkSign($data)
     {
-        $in_sign = $data['sign'];
+        $in_sign = data_get($data, 'sign');
         unset($data['sign']);
         $data = array_filter($data);
         ksort($data);


### PR DESCRIPTION
```bash
Undefined index: sign {"exception":"[object] (ErrorException(code: 0): Undefined index: sign at /vendor/xhat/payjs-laravel/src/Payjs.php:138
```